### PR TITLE
[Fix] Palindrome checker

### DIFF
--- a/Beginner/palindromeChecker/index-SOLUTION.js
+++ b/Beginner/palindromeChecker/index-SOLUTION.js
@@ -1,39 +1,39 @@
 // AN INTUITIVE APPROACH
 
-function palindromeChecker (text) {
+function palindromeChecker(text) {
 
-  var reversedText = text.toLowerCase()
+    var reversedText = text.toLowerCase()
         .split('').reverse().join('')
 
-  return text === reversedText
+    return text === reversedText
 }
 
 
 // LOOPING THROUGH AND COMPARING CHARACTERS
 
 
-function palindromeChecker (text) {
-  let charArray = text.toLowerCase().split('')
+function palindromeChecker(text) {
+    let charArray = text.toLowerCase().split('')
 
-  let result = charArray.every((letter, index) => {
-    return letter === charArray[charArray.length - index - 1]
-  })
+    let result = charArray.every((letter, index) => {
+        return letter === charArray[charArray.length - index - 1];
+    })
 
-  return result
+    return result
 }
 
 // LOOPING THROUGH AND COMPARING CHARACTERS(OPTIMIZED)
 
 
-function palindromeChecker (text) {
-  const textLowered = text.toLowerCase()
-  const textLen = text.length
+function palindromeChecker(text) {
+    const textLowered = text.toLowerCase()
+    const textLen = text.length
 
-  for (let i = 0; i < textLen / 2; i++) {
-    if (textLowered[i] !== textLowered[textLen - i - 1]) {
-      return false
+    for (let i = 0; i < textLen / 2; i++) {
+        if (textLowered[i] !== textLowered[textLen - i - 1]) {
+            return false
+        }
     }
-  }
 
-  return true
+    return true
 }

--- a/Beginner/palindromeChecker/index-SOLUTION.js
+++ b/Beginner/palindromeChecker/index-SOLUTION.js
@@ -1,36 +1,39 @@
 // AN INTUITIVE APPROACH
 
-function palindromeChecker(text) {
+function palindromeChecker (text) {
 
-    var reversedText = text.toLowerCase()
+  var reversedText = text.toLowerCase()
         .split('').reverse().join('')
 
-    return text === reversedText
+  return text === reversedText
 }
 
 
 // LOOPING THROUGH AND COMPARING CHARACTERS
 
 
-function palindromeChecker(text) {
-    let charArray = text.toLowerCase().split('')
+function palindromeChecker (text) {
+  let charArray = text.toLowerCase().split('')
 
-    let result = charArray.every((letter, index) => {
-        return letter === charArray[charArray.length - index - 1];
-    })
+  let result = charArray.every((letter, index) => {
+    return letter === charArray[charArray.length - index - 1]
+  })
 
-    return result
+  return result
 }
 
 // LOOPING THROUGH AND COMPARING CHARACTERS(OPTIMIZED)
 
 
-function palindromeChecker(text) {
-    var textLen = text.length;
-    for (var i = 0; i < textLen / 2; i++) {
-        if (text[i] !== text[textLen - 1 - i]) {
-            return false;
-        }
+function palindromeChecker (text) {
+  const textLowered = text.toLowerCase()
+  const textLen = text.length
+
+  for (let i = 0; i < textLen / 2; i++) {
+    if (textLowered[i] !== textLowered[textLen - i - 1]) {
+      return false
     }
-    return true;
+  }
+
+  return true
 }


### PR DESCRIPTION
Hello!

A small pull request so as to fix a slight issue for the optimized solution of the palindrome checker.
Right now, the current solution doesn't manage words with uppercased letters.
Besides, I think there is no need to use the `var` keyword. We could use `const` and `let` keywords instead.

Regards,